### PR TITLE
Copy existing metafiles to payload instead of creating new ones

### DIFF
--- a/iforce_quick_compile.py
+++ b/iforce_quick_compile.py
@@ -68,25 +68,33 @@ class iforce_quick_compileCommand(sublime_plugin.WindowCommand):
 
 			pfilename, pfileext = os.path.splitext(fileTail)
 			print 'iForce: filename without extension ' + pfilename
-			
 
-			# write meta file	
-			if payloadMetaTag == 'ApexPage':
-				metaFileContent = '<?xml version="1.0" encoding="UTF-8"?>\n<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata"><apiVersion>25.0</apiVersion><description>'+pfilename+'</description><label>'+pfilename+'</label></ApexPage>'
+
+			# try to copy existing meta file
+			# if it does not exist, create one
+			pmetapath = self.currentFile + '-meta.xml'
+			if os.path.exists(pmetapath):
+				pmetaname = os.path.basename(pmetapath)
+				destFile = self.payloadFolder + '/' + self.payloadType + '/' + pmetaname
+				shutil.copyfile(pmetapath, destFile)
 			else:
-				metaFileContent = '<?xml version="1.0" encoding="UTF-8"?>\n<'+payloadMetaTag+' xmlns="http://soap.sforce.com/2006/04/metadata"><apiVersion>25.0</apiVersion><status>Active</status></'+payloadMetaTag+'>'
-			metaFile = self.payloadFolder + '/' + self.payloadType + '/' + fileTail + '-meta.xml'
-			fhandle = open(metaFile,'w')
-			fhandle.write(metaFileContent) 
-			fhandle.close()
+				# write meta file
+				if payloadMetaTag == 'ApexPage':
+					metaFileContent = '<?xml version="1.0" encoding="UTF-8"?>\n<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata"><apiVersion>25.0</apiVersion><description>'+pfilename+'</description><label>'+pfilename+'</label></ApexPage>'
+				else:
+					metaFileContent = '<?xml version="1.0" encoding="UTF-8"?>\n<'+payloadMetaTag+' xmlns="http://soap.sforce.com/2006/04/metadata"><apiVersion>25.0</apiVersion><status>Active</status></'+payloadMetaTag+'>'
+				metaFile = self.payloadFolder + '/' + self.payloadType + '/' + fileTail + '-meta.xml'
+				fhandle = open(metaFile,'w')
+				fhandle.write(metaFileContent)
+				fhandle.close()
 
 			# write package file
 			packageFileContent = '<?xml version="1.0" encoding="UTF-8"?>\n<Package xmlns="http://soap.sforce.com/2006/04/metadata"> <types> <members>'+pfilename+'</members> <name>'+payloadMetaTag+'</name> </types> <version>22.0</version> </Package>'
-			packageFile = self.payloadFolder + '/package.xml' 
-			
+			packageFile = self.payloadFolder + '/package.xml'
+
 
 			fhandle = open(packageFile,'w')
-			fhandle.write(packageFileContent) 
+			fhandle.write(packageFileContent)
 			fhandle.close()
 
 			self.window.run_command('exec', {'cmd': [self.antBin, "qcompile"], 'working_dir':self.prjFolder})


### PR DESCRIPTION
Modified the code so that, if the file to be deployed already has a "-meta.xml" file, Quick Compile will copy that file to the payload instead of creating a new file.

This helps maintain the API version the project is already using, instead of assuming API version 25.
