### PR TITLE
Fix merge gone wrong, ant calls still look for build.xml

### DIFF
--- a/iforce_quick_compile.py
+++ b/iforce_quick_compile.py
@@ -97,7 +97,7 @@ class iforce_quick_compileCommand(sublime_plugin.WindowCommand):
 			fhandle.write(packageFileContent)
 			fhandle.close()
 
-			self.window.run_command('exec', {'cmd': [self.antBin, "qcompile"], 'working_dir':self.prjFolder})
+                        self.window.run_command('exec', {'cmd': [self.antBin, "-file", "iForce_build.xml", "-propertyfile", "iForce_build.properties", "qcompile"], 'working_dir':self.prjFolder})
 
 		except Exception, e:
 			print 'iForce: You should run with a file open.'

--- a/iforce_refresh_from_server.py
+++ b/iforce_refresh_from_server.py
@@ -15,5 +15,4 @@ class iforce_refresh_from_serverCommand(sublime_plugin.WindowCommand):
 		self.currentProjectFolder = self.window.folders()[0]
 		print 'iForce: Prj Path: ' + self.currentProjectFolder
 		# os.chdir(folder)
-		self.window.run_command('exec', {'cmd': [self.antBin, "getLatest"], 'working_dir':self.currentProjectFolder})
-
+                self.window.run_command('exec', {'cmd': [self.antBin, "-file", "iForce_build.xml", "-propertyfile", "iForce_build.properties", "getLatest"], 'working_dir':self.currentProjectFolder})


### PR DESCRIPTION
Seems that after the merge, the quick compile and server refresh commands are still looking for the build.\* files instead of the iForce_build.\* files.
